### PR TITLE
Removed Net Standard Library

### DIFF
--- a/src/Serilog.Sinks.Redis.Core/project.json
+++ b/src/Serilog.Sinks.Redis.Core/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.0",
+  "version": "1.0.1",
   "authors": [ "Devon Burriss" ],
   "description": "Core functionality shared across Serilog Redis sinks",
   "packOptions": {
@@ -17,6 +17,8 @@
   },
 
   "frameworks": {
-    "net451": {}
+    "net451": {},
+    "net46": {},
+    "net461": {}
   }
 }

--- a/src/Serilog.Sinks.Redis.Core/project.json
+++ b/src/Serilog.Sinks.Redis.Core/project.json
@@ -1,10 +1,12 @@
 ﻿{
   "version": "1.0.0",
   "authors": [ "Devon Burriss" ],
+  "description": "Core functionality shared across Serilog Redis sinks",
   "packOptions": {
     "licenseUrl": "https://github.com/dburriss/serilog-sinks-redis/blob/master/LICENSE",
     "projectUrl": "https://github.com/dburriss/serilog-sinks-redis",
-    "iconUrl": "http://serilog.net/images/serilog-sink-nuget.png"
+    "iconUrl": "http://serilog.net/images/serilog-sink-nuget.png",
+    "tags": [ "logging", "serilog", "sink", "redis" ]
   },
 
   "dependencies": {

--- a/src/Serilog.Sinks.Redis.Core/project.json
+++ b/src/Serilog.Sinks.Redis.Core/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.1",
+  "version": "1.0.2",
   "authors": [ "Devon Burriss" ],
   "description": "Core functionality shared across Serilog Redis sinks",
   "packOptions": {
@@ -10,7 +10,6 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
     "Serilog.Formatting.Compact": "1.0.0",
     "Serilog.Sinks.PeriodicBatching": "2.0.0",
     "StackExchange.Redis": "1.1.603"

--- a/src/Serilog.Sinks.Redis.List/project.json
+++ b/src/Serilog.Sinks.Redis.List/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0",
+  "version": "1.0.1",
   "authors": [ "Devon Burriss" ],
   "title": "Serilog Redis List Sinks",
   "description": "Serilog Redis sinks that logs to a Redis List type",
@@ -14,11 +14,13 @@
     "NETStandard.Library": "1.6.0",
     "Serilog.Formatting.Compact": "1.0.0",
     "Serilog.Sinks.PeriodicBatching": "2.0.0",
-    "Serilog.Sinks.Redis.Core": "1.0.0",
+    "Serilog.Sinks.Redis.Core": "1.0.1",
     "StackExchange.Redis": "1.1.603"
   },
 
   "frameworks": {
-    "net451": {}
+    "net451": {},
+    "net46": {},
+    "net461": {}
   }
 }

--- a/src/Serilog.Sinks.Redis.List/project.json
+++ b/src/Serilog.Sinks.Redis.List/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.1",
+  "version": "1.0.2",
   "authors": [ "Devon Burriss" ],
   "title": "Serilog Redis List Sinks",
   "description": "Serilog Redis sinks that logs to a Redis List type",
@@ -11,7 +11,6 @@
   },
 
   "dependencies": {
-    "NETStandard.Library": "1.6.0",
     "Serilog.Formatting.Compact": "1.0.0",
     "Serilog.Sinks.PeriodicBatching": "2.0.0",
     "Serilog.Sinks.Redis.Core": "1.0.1",

--- a/src/Serilog.Sinks.Redis.List/project.json
+++ b/src/Serilog.Sinks.Redis.List/project.json
@@ -1,10 +1,13 @@
 {
   "version": "1.0.0",
-  "authors": ["Devon Burriss"],
+  "authors": [ "Devon Burriss" ],
+  "title": "Serilog Redis List Sinks",
+  "description": "Serilog Redis sinks that logs to a Redis List type",
   "packOptions": {
     "licenseUrl": "https://github.com/dburriss/serilog-sinks-redis/blob/master/LICENSE",
     "projectUrl": "https://github.com/dburriss/serilog-sinks-redis",
-    "iconUrl": "http://serilog.net/images/serilog-sink-nuget.png"
+    "iconUrl": "http://serilog.net/images/serilog-sink-nuget.png",
+    "tags": [ "logging", "serilog", "sink", "redis", "list", "structured" ]
   },
 
   "dependencies": {

--- a/test/Serilog.Sinks.Redis.IntegrationTests/project.json
+++ b/test/Serilog.Sinks.Redis.IntegrationTests/project.json
@@ -3,11 +3,11 @@
   "testRunner": "xunit",
   "dependencies": {
     "xunit": "2.2.0-beta2-build3300",
-    "Serilog.Sinks.Redis.List": "1.0.0",
+    "Serilog.Sinks.Redis.List": "1.0.1",
     "Serilog": "2.1.0",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "frameworks": {
-    "net451": {}
+    "net461": {}
   }
 }

--- a/test/Serilog.Sinks.Redis.Tests/project.json
+++ b/test/Serilog.Sinks.Redis.Tests/project.json
@@ -3,12 +3,12 @@
   "testRunner": "xunit",
   "dependencies": {
     "xunit": "2.2.0-beta2-build3300",
-    "Serilog.Sinks.Redis.List": "1.0.0",
+    "Serilog.Sinks.Redis.List": "1.0.1",
     "Serilog": "2.1.0",
     "JustMock": "2016.2.426.1",
     "dotnet-test-xunit": "2.2.0-preview2-build1029"
   },
   "frameworks": {
-    "net451": {}
+    "net461": {}
   }
 }


### PR DESCRIPTION
In response to people experiencing this issue:
https://github.com/dotnet/corefx/issues/9884

This will be resolved in 1.1 version.
