### PR TITLE
Fix #20

### DIFF
--- a/src/Serilog.Sinks.Redis.List/NoConnectionMultiplexer.cs
+++ b/src/Serilog.Sinks.Redis.List/NoConnectionMultiplexer.cs
@@ -166,7 +166,7 @@ namespace Serilog.Sinks.Redis.List
         public bool IncludeDetailInExceptions { get; set; }
         public int StormLogThreshold { get; set; }
 
-        public bool IsConnecting => throw new NotImplementedException();
+        public bool IsConnecting { get; }
 
         public event EventHandler<RedisErrorEventArgs> ErrorMessage;
         public event EventHandler<ConnectionFailedEventArgs> ConnectionFailed;


### PR DESCRIPTION
This property was introduced in https://github.com/dburriss/serilog-sinks-redis/pull/24 after updating `StackExchange.Redis`. It is throwing exceptions when it is accessed, probably because the interface has been auto-implemented with default behavior.